### PR TITLE
Fix pathdomain

### DIFF
--- a/wpseku.py
+++ b/wpseku.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with WPSeku; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# Add path to seft.target
 
 
 from lib import wpcolor

--- a/wpseku.py
+++ b/wpseku.py
@@ -105,7 +105,7 @@ class WPSeku(object):
 		if netloc == "":
 			return "http://"+path
 		else:
-			return scheme+"://"+netloc
+			return scheme+"://"+netloc+path
 
 	def Main(self):
 		if len(sys.argv) <= 2:


### PR DESCRIPTION
Add:
```
def CheckTarget(self,url):
		scheme = urlparse.urlsplit(url).scheme
		netloc = urlparse.urlsplit(url).netloc
		path = urlparse.urlsplit(url).path
		if scheme not in ['http','https','']:
			sys.exit(self.printf.erro('Schme %s not supported'%(scheme)))
		if netloc == "":
			return "http://"+path
		else:
			return scheme+"://"+netloc+path
```
So that wordpress installations not in domain root could be scanned too.