### PR TITLE
Fix for directory listing and wp-config availability

### DIFF
--- a/modules/discovery/generic/wpconfig.py
+++ b/modules/discovery/generic/wpconfig.py
@@ -35,8 +35,9 @@ class wpconfig:
 		try:
 			url = self.check.checkurl(self.url,'/wp-config.php')
 			resp = self.req.send(url)
-			if resp.read() and resp.getcode() == 200:
-				if re.search('\S+define(\S+,*)',resp.read()):
+			html = resp.read()
+			if html and resp.getcode() == 200:
+				if re.search('\S+define(\S+,*)',html):
 					self.printf.plus('wp-config available under: %s'%(url))
 				else:
 					self.printf.erro('wp-config not available')

--- a/modules/discovery/generic/wplisting.py
+++ b/modules/discovery/generic/wplisting.py
@@ -37,8 +37,9 @@ class wplisting:
             try:
                 url = self.check.checkurl(self.url,i)
                 resp = self.req.send(url)
-                if resp.read() and resp.getcode() == 200:
-                    if re.search('Index of',resp.read()):
+                html = resp.read()
+                if html and resp.getcode() == 200:
+                    if re.search('Index of',html):
                         self.printf.plus('dir %s listing enabled under: %s'%(i,url))
                     else:
                         self.printf.erro('dir %s not listing enabled'%(i))


### PR DESCRIPTION
Directory listing and wp-config availability checks are not working because resp.read() is called twice, once it is firstly consumed, it can not be used a second time.
This pull request fix that issue.