### PR TITLE
Suppress the InsecureRequestWarning for #24.

### DIFF
--- a/lib/wphttp.py
+++ b/lib/wphttp.py
@@ -82,7 +82,7 @@ class wphttp(object):
 			h['user-agent'] = self.agent
 		# request
 		request = requests.Session()
-		req = urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+		req = requests.packages.urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 		# get
 		if m.lower()=='get':
 			if p: u='{}'.format(Request.ucheck.payload(u,p))


### PR DESCRIPTION
This is the only instance where `requests` was being used without the `disable_warnings` being called. Therefore, I changed it to be `requests.packages.urllib3.disable_warnings` instead of `urllib3.disable_warnings`. This should resolve #24. I personally tried to replicate the issue on a couple different instances, however, could not seem to get the issue to happen on Mac OSX with `Python 2.7.14` and libraries `requests==2.18.4` and `urllib3==1.22`.