### PR TITLE
fix detection logic, json parsing, and add a gitignore

### DIFF
--- a/modules/.gitignore
+++ b/modules/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/modules/discovery/users/wpusers.py
+++ b/modules/discovery/users/wpusers.py
@@ -4,7 +4,8 @@
 # WPSeku - Wordpress Security Scanner
 # by Momo Outaadi (m4ll0k)
 
-from json import loads
+from json import loads, decoder
+import sys
 from lib.check import *
 from lib.request import * 
 from lib.printer import *
@@ -60,9 +61,12 @@ class wpusers(Request):
 		url = Path(self.url,'/?rest_route=/wp/v2/users')
 		resp = self.send(url=url,method="GET")
 		if resp.status_code == 200:
-			json = loads(resp.content,encoding="utf-8")
-			for x in range(len(json)):
-				users.append((json[x]['name'],json[x]['slug']))
+			try:
+				json = loads(resp.content,encoding="utf-8")
+				for x in range(len(json)):
+				    users.append((json[x]['name'],json[x]['slug']))
+			except json.decoder.JSONDecodeError:
+				pass            
 		return users
 
 	def wpfeed(self):

--- a/modules/fingerprint/cms.py
+++ b/modules/fingerprint/cms.py
@@ -12,7 +12,7 @@ def wordpress(headers,content):
 	_cms_ |= search(decode('<meta name="generator" content="WordPress.com" />'),content) is not None
 	_cms_ |= search(decode('<a href="http://www.wordpress.com">Powered by WordPress</a>'),content) is not None
 	_cms_ |= search(decode('<link rel=\'https://api.w.org/\''),content) is not None
-	_cms_ |= search(decode('/wp-content/plugins/|/wp-admin/admin-ajax.php'),content) is not None
+	_cms_ |= search(decode('\\?\/wp-content\\?\/plugins\/|\\?\/wp-admin\\?\/admin-ajax.php'),content) is not None
 	if _cms_:
 		return "wordpress"
 


### PR DESCRIPTION
- Expanded the logic for wordpress detection, frequently it will look like the following
```
var page = {"site_url":"https:\/\/www.site.com","ajaxurl":"https:\/\/www.site.com\/wp-admin\/admin-ajax.php","country":"...
```

- Corrected an issue where wpjson2() was expecting the results of /?rest_route=/wp/v2/users to be JSON, when in fact it will frequently not be. 

- Added a gitignore so that one isn't annoyed be pyc files.