### PR TITLE
Removed part of matching string to match these kind of installations:…

### DIFF
--- a/modules/fingerprint/cms.py
+++ b/modules/fingerprint/cms.py
@@ -6,7 +6,7 @@ from lib.printer import *
 
 def wordpress(headers,content):
 	_cms_ = False
-	_cms_ |= search(decode('<meta name="generator" content="WordPress.com" />'),content) is not None
+	_cms_ |= search(decode('<meta name="generator" content="WordPress'),content) is not None
 	_cms_ |= search(decode('<a href="http://www.wordpress.com">Powered by WordPress</a>'),content) is not None
 	_cms_ |= search(decode('<link rel=\'https://api.w.org/\''),content) is not None
 	_cms_ |= search(decode('\\?\/wp-content\\?\/plugins\/|\\?\/wp-admin\\?\/admin-ajax.php'),content) is not None


### PR DESCRIPTION
Removed part of matching string to match these kind of installations:

`<meta name="generator" content="WordPress 4.0.0" />`

This may fixes #35 