### PR TITLE
Added try block, so scan doesn't crash if file can't be decoded

### DIFF
--- a/lib/scan.py
+++ b/lib/scan.py
@@ -55,8 +55,15 @@ class Scan:
 			plus('Scanning directory...')
 			files = self.recursive(source,'*.php')
 			for file in files:
-				info('Scanning %s file'%file)
-				self.testFile(file)
+				try:
+					with open(file, 'tr') as check_file:  # Try open file in text mode
+						check_file.read()
+						info('Scanning %s file'%file)
+						self.testFile(file)
+				except:  # If check_file.read fails, then file is non-text (possibly binary)
+					warn("Skipping %s"%file)
+					pass
+
 		else:
 			plus('Scanning file...')
 			file = self.check(source)


### PR DESCRIPTION
The scan would crash if the file couldn't be decoded in UTF-8, so added a try block to skip the file if it can't opened and read as text (skips the decode call entirely).

Referenced in #45 
