### PR TITLE
Change timeout to INT

### DIFF
--- a/wpseku.py
+++ b/wpseku.py
@@ -42,7 +42,7 @@ class wpseku(object):
 			if opt in ('-p','--proxy'):self.kwargs['proxy']=arg
 			if opt in ('-c','--cookie'):self.kwargs['cookie']=arg
 			if opt in ('-a','--agent'):self.kwargs['agent']=arg
-			if opt in ('-t','--timeout'):self.kwargs['timeout']=arg
+			if opt in ('-t','--timeout'):self.kwargs['timeout']=int(arg)
 			if opt in ('-R','--redirect'):self.kwargs['redirect']=True
 			if opt in ('-r','--ragent'):self.kwargs['ragent']=True
 			if opt in ('-v','--verbose'):self.kwargs['verbose']=True


### PR DESCRIPTION
Adding a timeout duration currently results in an error due to the improper input type.

Changed to INT and error is no longer occurring.

Initial error:
```
Traceback (most recent call last):
  File "./wpseku.py", line 71, in <module>
    wpseku().main()
  File "./wpseku.py", line 61, in main
    fingerprint(self.url,None,self.kwargs).run()
  File "/usr/src/app/modules/fingerprint/fingerprint.py", line 16, in run
    req = self.send(url=self.url)
  File "/usr/src/app/lib/request.py", line 50, in send
    'https':self.kwarg['proxy']
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/requests/adapters.py", line 435, in send
    timeout = TimeoutSauce(connect=timeout, read=timeout)
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/timeout.py", line 94, in __init__
    self._connect = self._validate_timeout(connect, 'connect')
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/timeout.py", line 136, in _validate_timeout
    "int, float or None." % (name, value))
ValueError: Timeout value connect was 5, but it must be an int, float or None.
```